### PR TITLE
Fixes `Miss.Map.from_nested_struct/2`

### DIFF
--- a/lib/miss/map.ex
+++ b/lib/miss/map.ex
@@ -38,7 +38,7 @@ defmodule Miss.Map do
       end
 
       defmodule Metadata do
-        defstruct [:atom, :boolean, :decimal, :float, :integer]
+        defstruct [:atom, :boolean, :decimal, :float, :integer, map: %{}]
       end
 
       # Convert all nested structs including the Date and Decimal values:
@@ -159,14 +159,16 @@ defmodule Miss.Map do
   defp to_map(value, _transform), do: value
 
   @spec to_nested_map(struct() | map(), transform()) :: map()
-  defp to_nested_map(value, transform) do
-    value
+  defp to_nested_map(struct_or_map, transform) do
+    struct_or_map
     |> Map.keys()
     |> Enum.reduce(%{}, fn key, map ->
-      value
-      |> Map.get(key)
-      |> to_map(transform)
-      |> then(&Map.put(map, key, &1))
+      value =
+        struct_or_map
+        |> Map.get(key)
+        |> to_map(transform)
+
+      Map.put(map, key, value)
     end)
   end
 

--- a/test/miss/map_test.exs
+++ b/test/miss/map_test.exs
@@ -17,7 +17,7 @@ defmodule Miss.MapTest do
   end
 
   defmodule Metadata do
-    defstruct [:atom, :boolean, :decimal, :float, :integer]
+    defstruct [:atom, :boolean, :decimal, :float, :integer, map: %{}]
   end
 
   doctest Subject
@@ -51,7 +51,10 @@ defmodule Miss.MapTest do
             boolean: true,
             decimal: Decimal.new("456.78"),
             float: 987.54,
-            integer: 2_345_678
+            integer: 2_345_678,
+            map: %{
+              meta: %Comment{text: "Comment one"}
+            }
           }
         },
         comments: [
@@ -75,7 +78,10 @@ defmodule Miss.MapTest do
             boolean: true,
             decimal: %{coef: 45_678, exp: -2, sign: 1},
             float: 987.54,
-            integer: 2_345_678
+            integer: 2_345_678,
+            map: %{
+              meta: %{text: "Comment one"}
+            }
           }
         },
         comments: [
@@ -102,7 +108,10 @@ defmodule Miss.MapTest do
             boolean: true,
             decimal: 456.78,
             float: 987.54,
-            integer: 2_345_678
+            integer: 2_345_678,
+            map: %{
+              meta: "Comment one"
+            }
           }
         },
         comments: ["Comment one", "Comment two"]
@@ -133,7 +142,10 @@ defmodule Miss.MapTest do
             boolean: true,
             decimal: Decimal.new("456.78"),
             float: 987.54,
-            integer: 2_345_678
+            integer: 2_345_678,
+            map: %{
+              meta: %{text: "Comment one"}
+            }
           }
         },
         comments: [


### PR DESCRIPTION
When a struct was nested into a map, the struct was not converted to map.